### PR TITLE
Enable offline authentication via COPILOT_OFFLINE

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ To get the latest security fixes, please use the latest version of the Copilot e
 * **[Feedback](https://github.com/microsoft/vscode-copilot-release/issues)**: We'd love to get your help in making GitHub Copilot better!
 * Configure a custom OpenAI endpoint for Bring Your Own Key using the `github.copilot.chat.byok.customOpenAIEndpoint` setting.
 * For offline use, patch `VSCodeCopilotTokenManager._auth` to return a dummy token so no GitHub authorization is required.
+* When running offline, set the `COPILOT_OFFLINE` environment variable to `1` so the extension uses a dummy GitHub session.
 
 ## Data and telemetry
 

--- a/src/extension/extension/vscode-node/services.ts
+++ b/src/extension/extension/vscode-node/services.ts
@@ -8,6 +8,7 @@ import { IAuthenticationService } from '../../../platform/authentication/common/
 import { ICopilotTokenManager } from '../../../platform/authentication/common/copilotTokenManager';
 import { getOrCreateTestingCopilotTokenManager } from '../../../platform/authentication/node/copilotTokenManager';
 import { AuthenticationService } from '../../../platform/authentication/vscode-node/authenticationService';
+import { OfflineAuthenticationService } from '../../../platform/authentication/vscode-node/offlineAuthenticationService';
 import { VSCodeCopilotTokenManager } from '../../../platform/authentication/vscode-node/copilotTokenManager';
 import { IChatAgentService } from '../../../platform/chat/common/chatAgents';
 import { IChatMLFetcher } from '../../../platform/chat/common/chatMLFetcher';
@@ -138,7 +139,11 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 		setupTelemetry(builder, extensionContext, internalAIKey, internalLargeEventAIKey, ariaKey);
 		builder.define(ICopilotTokenManager, new SyncDescriptor(VSCodeCopilotTokenManager));
 	}
-	builder.define(IAuthenticationService, new SyncDescriptor(AuthenticationService));
+	if (process.env.COPILOT_OFFLINE === '1') {
+		builder.define(IAuthenticationService, new SyncDescriptor(OfflineAuthenticationService, [undefined]));
+	} else {
+		builder.define(IAuthenticationService, new SyncDescriptor(AuthenticationService));
+	}
 
 	builder.define(ITestGenInfoStorage, new SyncDescriptor(TestGenInfoStorage)); // Used for test generation (/tests intent)
 	builder.define(IEndpointProvider, new SyncDescriptor(ProductionEndpointProvider, [collectFetcherTelemetry]));

--- a/src/platform/authentication/vscode-node/offlineAuthenticationService.ts
+++ b/src/platform/authentication/vscode-node/offlineAuthenticationService.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { AuthenticationGetSessionOptions, AuthenticationSession } from 'vscode';
+import { BaseAuthenticationService, GITHUB_SCOPE_ALIGNED, GITHUB_SCOPE_USER_EMAIL, IAuthenticationService, MinimalModeError } from '../common/authentication';
+import { CopilotToken } from '../common/copilotToken';
+import { ICopilotTokenManager } from '../common/copilotTokenManager';
+import { ICopilotTokenStore } from '../common/copilotTokenStore';
+import { getStaticGitHubToken } from '../node/copilotTokenManager';
+import { IConfigurationService } from '../../configuration/common/configurationService';
+import { ILogService } from '../../log/common/logService';
+
+export class OfflineAuthenticationService extends BaseAuthenticationService {
+	private _githubToken: string | undefined;
+	private readonly tokenProvider: { (): string };
+
+	get githubToken(): string {
+		if (!this._githubToken) {
+			this._githubToken = this.tokenProvider();
+		}
+		return this._githubToken;
+	}
+
+	constructor(
+		tokenProvider: { (): string } | undefined,
+		@ILogService logService: ILogService,
+		@ICopilotTokenStore tokenStore: ICopilotTokenStore,
+		@ICopilotTokenManager tokenManager: ICopilotTokenManager,
+		@IConfigurationService configurationService: IConfigurationService
+	) {
+		super(logService, tokenStore, tokenManager, configurationService);
+		this.tokenProvider = tokenProvider || getStaticGitHubToken;
+
+		const that = this;
+		this._anyGitHubSession = {
+			get id() { return that.githubToken; },
+			get accessToken() { return that.githubToken; },
+			scopes: GITHUB_SCOPE_USER_EMAIL,
+			account: { id: 'user', label: 'User' }
+		};
+
+		this._permissiveGitHubSession = {
+			get id() { return that.githubToken; },
+			get accessToken() { return that.githubToken; },
+			scopes: GITHUB_SCOPE_ALIGNED,
+			account: { id: 'user', label: 'User' }
+		};
+	}
+
+	getAnyGitHubSession(_options?: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {
+		return Promise.resolve(this._anyGitHubSession);
+	}
+
+	getPermissiveGitHubSession(options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {
+		if (this.isMinimalMode) {
+			if (options.createIfNone || options.forceNewSession) {
+				throw new MinimalModeError();
+			}
+			return Promise.resolve(undefined);
+		}
+		return Promise.resolve(this._permissiveGitHubSession);
+	}
+
+	override async getCopilotToken(force?: boolean): Promise<CopilotToken> {
+		return await super.getCopilotToken(force);
+	}
+
+	setCopilotToken(token: CopilotToken): void {
+		this._tokenStore.copilotToken = token;
+		this._onDidAuthenticationChange.fire();
+	}
+
+	override getAdoAccessTokenBase64(options?: AuthenticationGetSessionOptions): Promise<string | undefined> {
+		return Promise.resolve(undefined);
+	}
+}


### PR DESCRIPTION
## Summary
- add `COPILOT_OFFLINE` instructions to README
- add `OfflineAuthenticationService` class for use when running offline
- wire up offline authentication service when `COPILOT_OFFLINE=1`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68888c68bc8c832a9ade267524979a0a